### PR TITLE
Update Cargo manifest about project metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "pacnews"
 version = "2.2.0"
+description = "Read the latest Arch Linux news in your terminal with a single command"
 authors = ["Alessio Biancalana <dottorblaster@gmail.com>"]
+license = "MIT"
+readme = "README.md"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
This PR adds `description`, `license` and `readme` fields to `Cargo.toml`.
