### PR TITLE
feat: add -n, --count flag to specify number of news in the feed to display

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::{Args, Sort};
 
-pub fn get_config_options(config: Args) -> (Sort, bool, bool) {
-    (config.sort, config.lookup, config.colors)
+pub fn get_config_options(config: Args) -> (Sort, bool, bool, Option<u16>) {
+    (config.sort, config.lookup, config.colors, config.count)
 }
 
 #[cfg(test)]
@@ -14,12 +14,14 @@ mod tests {
             sort: Sort::Asc,
             lookup: true,
             colors: true,
+            count: Some(16),
         };
 
-        let (sorting, is_lookup_enabled, colors) = get_config_options(config);
+        let (sorting, is_lookup_enabled, colors, count) = get_config_options(config);
 
         assert_eq!(sorting, Sort::Asc);
         assert_eq!(is_lookup_enabled, true);
         assert_eq!(colors, true);
+        assert_eq!(count, Some(16));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::{Args, Sort};
 
 pub fn get_config_options(config: Args) -> (Sort, bool, bool, Option<u16>) {
-    (config.sort, config.lookup, config.colors, config.count)
+    (config.sort, config.lookup, config.colors, config.number)
 }
 
 #[cfg(test)]
@@ -14,7 +14,7 @@ mod tests {
             sort: Sort::Asc,
             lookup: true,
             colors: true,
-            count: Some(16),
+            number: Some(16),
         };
 
         let (sorting, is_lookup_enabled, colors, count) = get_config_options(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ pub struct Args {
     lookup: bool,
     #[arg(short, long, action=ArgAction::SetFalse, help = "Enable colored output for entries")]
     colors: bool,
-    #[arg(short('n'), long, help = "Number of news articles to print")]
+    #[arg(short, long, help = "Number of news articles to print")]
     number: Option<u16>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ pub struct Args {
     lookup: bool,
     #[arg(short, long, action=ArgAction::SetFalse, help = "Enable colored output for entries")]
     colors: bool,
+    #[arg(short('n'), long, help = "Number of news articles to print")]
+    count: Option<u16>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -39,7 +41,7 @@ pub enum Sort {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Args::parse();
 
-    let (sort, lookup, colors) = config::get_config_options(config);
+    let (sort, lookup, colors, count) = config::get_config_options(config);
 
     let items = feed::get_items(FEED_URL, &sort)?;
 
@@ -55,7 +57,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false => entry::map_rss_items_to_entries(items),
     };
 
-    for entry in entries {
+    let entries = count
+        .map(|c| &entries[..(c as usize).min(entries.len())])
+        .unwrap_or(&entries);
+
+    for entry in entries.iter().cloned() {
         if colors {
             let colored_entry = entry::ColoredEntry::from(entry);
             println!("{colored_entry}")

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ pub struct Args {
     #[arg(short, long, action=ArgAction::SetFalse, help = "Enable colored output for entries")]
     colors: bool,
     #[arg(short('n'), long, help = "Number of news articles to print")]
-    count: Option<u16>,
+    number: Option<u16>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]


### PR DESCRIPTION
The -n, --count <N> flag will take N articles from the feed and display them to the console. Not specifying it will simply print the full array.

This is mainly useful to me for `pacnews -n 1` where I can see just the most recent article right before an update.